### PR TITLE
feat: add get_project_fact to HITL whitelist

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,7 +138,7 @@ hitl:
   # 已决策审计日志保留天数（与 MCP 监控一致；省略默认 90；0 表示不自动清理）
   retention_days: 90
   # 按你环境里的真实工具名增删（与侧栏一致、小写不敏感）；不需要全局免审批可改为 []
-  tool_whitelist: [read_file, list_dir, glob, grep, tool_search, upsert_project_fact]
+  tool_whitelist: [read_file, list_dir, glob, grep, tool_search, upsert_project_fact, get_project_fact]
   # audit_agent_prompt: |  # 审批模式；留空使用内置默认，可在「人机协同」页编辑
   # audit_agent_prompt_review_edit: |  # 审查编辑模式；留空使用内置默认
 

--- a/internal/multiagent/hitl_toolsearch_compat.go
+++ b/internal/multiagent/hitl_toolsearch_compat.go
@@ -22,6 +22,7 @@ var HitlExemptMetaTools = []string{
 	"TaskUpdate",
 	"TaskList",
 	"upsert_project_fact",
+	"get_project_fact",
 }
 
 // IsToolSearchTool reports whether name is the Eino dynamictool tool_search meta-tool.

--- a/internal/multiagent/hitl_toolsearch_compat_test.go
+++ b/internal/multiagent/hitl_toolsearch_compat_test.go
@@ -45,14 +45,19 @@ func TestMergeHitlExemptMetaTools_includesToolSearch(t *testing.T) {
 	if !found {
 		t.Fatalf("tool_search missing from %v", merged)
 	}
-	foundProjectFact := false
+	foundProjectFactTools := map[string]bool{
+		"upsert_project_fact": false,
+		"get_project_fact":    false,
+	}
 	for _, name := range merged {
-		if strings.EqualFold(strings.TrimSpace(name), "upsert_project_fact") {
-			foundProjectFact = true
-			break
+		normalized := strings.ToLower(strings.TrimSpace(name))
+		if _, ok := foundProjectFactTools[normalized]; ok {
+			foundProjectFactTools[normalized] = true
 		}
 	}
-	if !foundProjectFact {
-		t.Fatalf("upsert_project_fact missing from %v", merged)
+	for name, found := range foundProjectFactTools {
+		if !found {
+			t.Fatalf("%s missing from %v", name, merged)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- exempt `get_project_fact` from HITL approval as a read-only project fact lookup tool
- include it in the default example whitelist next to `upsert_project_fact`
- extend the whitelist regression test to cover both project fact tools

## Tests

- `go test ./internal/multiagent`
- `go test ./internal/config`
- `go test ./internal/handler`
- `git diff --check`