### PR TITLE
feat: 将 write_file 加入 HITL 默认白名单

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,7 +138,7 @@ hitl:
   # 已决策审计日志保留天数（与 MCP 监控一致；省略默认 90；0 表示不自动清理）
   retention_days: 90
   # 按你环境里的真实工具名增删（与侧栏一致、小写不敏感）；不需要全局免审批可改为 []
-  tool_whitelist: [read_file, list_dir, glob, grep, tool_search, upsert_project_fact]
+  tool_whitelist: [read_file, write_file, list_dir, glob, grep, tool_search, upsert_project_fact]
   # audit_agent_prompt: |  # 审批模式；留空使用内置默认，可在「人机协同」页编辑
   # audit_agent_prompt_review_edit: |  # 审查编辑模式；留空使用内置默认
 

--- a/internal/multiagent/hitl_toolsearch_compat.go
+++ b/internal/multiagent/hitl_toolsearch_compat.go
@@ -8,10 +8,11 @@ import (
 
 const toolSearchToolName = "tool_search"
 
-// HitlExemptMetaTools 为编排/元工具：不直接执行攻击动作，但会阻塞 agent 控制流。
+// HitlExemptMetaTools 为编排/元工具及限定在本地工作区的低风险工具。
 // tool_search 必须免审批，否则其 HITL 拒绝结果与 Eino toolsearch 中间件不兼容（会硬崩 ChatModel）。
 var HitlExemptMetaTools = []string{
 	toolSearchToolName,
+	"write_file",
 	"skill",
 	"task",
 	"write_todos",

--- a/internal/multiagent/hitl_toolsearch_compat_test.go
+++ b/internal/multiagent/hitl_toolsearch_compat_test.go
@@ -33,17 +33,23 @@ func TestHitlRejectToolResult_otherToolKeepsLegacyText(t *testing.T) {
 	}
 }
 
-func TestMergeHitlExemptMetaTools_includesToolSearch(t *testing.T) {
+func TestMergeHitlExemptMetaTools_includesBuiltInExemptions(t *testing.T) {
 	merged := MergeHitlExemptMetaTools([]string{"read_file"})
-	found := false
+	foundToolSearch := false
+	foundWriteFile := false
 	for _, name := range merged {
 		if IsToolSearchTool(name) {
-			found = true
-			break
+			foundToolSearch = true
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "write_file") {
+			foundWriteFile = true
 		}
 	}
-	if !found {
+	if !foundToolSearch {
 		t.Fatalf("tool_search missing from %v", merged)
+	}
+	if !foundWriteFile {
+		t.Fatalf("write_file missing from %v", merged)
 	}
 	foundProjectFact := false
 	for _, name := range merged {


### PR DESCRIPTION
## 修改说明

将 `write_file` 加入 HITL 内置免审批工具集合，并同步更新 `config.example.yaml` 中的默认工具白名单。

## 修改原因

`write_file` 只负责向 CyberStrikeAI 本地测试工作区保存脚本、临时文件和分析结果，本身不会执行文件内容，也不会直接向目标系统发起请求。每次调用都进入 HITL 审批会增加无意义的等待，并可能阻塞 Agent 连续保存测试脚本和证据的流程。

本修改只豁免 `write_file`，不会同时放行 `edit_file`、`execute`、WebShell 写入或其他能够直接改变目标状态的工具。

## 生效范围

- 新部署：`config.example.yaml` 默认白名单包含 `write_file`。
- 已有部署：运行时内置免审批集合会与现有 `hitl.tool_whitelist` 合并，因此不要求用户手工修改旧配置文件。
- 工具名仍按现有规则进行去空、忽略大小写和去重处理。

## 测试

```bash
GOCACHE=/private/tmp/cyberstrike-go-build go test ./internal/multiagent ./internal/config
```

测试通过，并新增断言确认合并后的内置免审批集合始终包含 `tool_search` 和 `write_file`。
