### PR TITLE
fix: sanitize MCP names for OpenAI tool calls

### DIFF
--- a/internal/einomcp/mcp_tools.go
+++ b/internal/einomcp/mcp_tools.go
@@ -45,14 +45,14 @@ func ToolsFromDefinitions(
 			return nil, fmt.Errorf("tool %q: %w", d.Function.Name, err)
 		}
 		out = append(out, &mcpBridgeTool{
-			info:           info,
-			name:           d.Function.Name,
-			agent:          ag,
-			holder:         holder,
-			record:         rec,
-			chunk:          toolOutputChunk,
-			invokeNotify:   invokeNotify,
-			einoAgentName:  strings.TrimSpace(einoAgentName),
+			info:          info,
+			name:          d.Function.Name,
+			agent:         ag,
+			holder:        holder,
+			record:        rec,
+			chunk:         toolOutputChunk,
+			invokeNotify:  invokeNotify,
+			einoAgentName: strings.TrimSpace(einoAgentName),
 		})
 	}
 	return out, nil
@@ -77,10 +77,27 @@ func toolInfoFromDefinition(d agent.Tool) (*schema.ToolInfo, error) {
 		// 空参数对象
 	}
 	return &schema.ToolInfo{
-		Name:        fn.Name,
+		Name:        sanitizeOpenAIToolName(fn.Name),
 		Desc:        fn.Description,
 		ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&js),
 	}, nil
+}
+
+// sanitizeOpenAIToolName converts MCP names to OpenAI's ^[a-zA-Z0-9_-]+$ format.
+// The original name remains on mcpBridgeTool and is still used for MCP routing.
+func sanitizeOpenAIToolName(name string) string {
+	name = strings.ReplaceAll(name, "::", "__")
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 type mcpBridgeTool struct {

--- a/internal/einomcp/mcp_tools_test.go
+++ b/internal/einomcp/mcp_tools_test.go
@@ -3,7 +3,39 @@ package einomcp
 import (
 	"strings"
 	"testing"
+
+	"cyberstrike-ai/internal/agent"
 )
+
+func TestToolInfoFromDefinitionSanitizesOpenAIToolName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "fs.read", want: "fs_read"},
+		{name: "nezha::server.exec", want: "nezha__server_exec"},
+		{name: "already-valid_1", want: "already-valid_1"},
+		{name: "space/slash", want: "space_slash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := toolInfoFromDefinition(agent.Tool{
+				Type: "function",
+				Function: agent.FunctionDefinition{
+					Name:       tt.name,
+					Parameters: map[string]interface{}{"type": "object"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("toolInfoFromDefinition() error = %v", err)
+			}
+			if info.Name != tt.want {
+				t.Fatalf("toolInfoFromDefinition() name = %q, want %q", info.Name, tt.want)
+			}
+		})
+	}
+}
 
 func TestUnknownToolReminderText(t *testing.T) {
 	s := unknownToolReminderText("bad_tool")


### PR DESCRIPTION
## Summary

- Fixes: MCP tools such as fs.read and nezha::server.exec are exposed unchanged as OpenAI function names, causing a 400 response because they do not match ^[a-zA-Z0-9_-]+$.
- Root cause: toolInfoFromDefinition copied the raw MCP name into schema.ToolInfo.Name even though that field is serialized as an OpenAI function name; the bridge already retains the raw name separately for MCP invocation.

## Regression evidence

- Before: `go test ./internal/einomcp -run TestToolInfoFromDefinitionSanitizesOpenAIToolName -count=1` exited `1`

- After: `go test ./internal/einomcp -run TestToolInfoFromDefinitionSanitizesOpenAIToolName -count=1` exited `0`

## Verification

- `go test ./...`
- `go vet ./internal/einomcp`
- `test -z "$(gofmt -l internal/einomcp/mcp_tools.go internal/einomcp/mcp_tools_test.go)"`

## Scope

- 2 files changed, +58 / -9 lines
