### PR TITLE
docs(hitl)：删除已下线 ASM 能力的残留说明

### DIFF
--- a/docs/en-US/hitl-best-practices.md
+++ b/docs/en-US/hitl-best-practices.md
@@ -25,7 +25,7 @@ hitl:
     api_key: ""
     model: "" # set a small model here; blank reuses the default AI channel model
   retention_days: 90
-  tool_whitelist: [read_file, ls, glob, grep, tool_search, get_project_fact, list_project_facts, search_project_facts, list_vulnerabilities, get_vulnerability, get_asset, query_assets, list_knowledge_risk_types, get_tool_execution, wait_tool_execution, batch_task_list, batch_task_get, asm_list_resources, manage_webshell_list, c2_event, c2_file]
+  tool_whitelist: [read_file, ls, glob, grep, tool_search, get_project_fact, list_project_facts, search_project_facts, list_vulnerabilities, get_vulnerability, get_asset, query_assets, list_knowledge_risk_types, get_tool_execution, wait_tool_execution, batch_task_list, batch_task_get, manage_webshell_list, c2_event, c2_file]
 ```
 
 `audit_model` supports partial configuration. Empty fields inherit from the resolved default AI channel, so the common setup is to fill only `model` and run approvals on a cheaper small model.
@@ -98,7 +98,7 @@ Allowlisted tools skip approval, so keep the list stable and low-risk. Recommend
 - Project and vulnerability reads: `get_project_fact`, `list_project_facts`, `search_project_facts`, `list_vulnerabilities`, `get_vulnerability`
 - Asset and knowledge-metadata reads: `get_asset`, `query_assets`, `list_knowledge_risk_types`
 - Execution and task-state reads: `get_tool_execution`, `wait_tool_execution`, `batch_task_list`, `batch_task_get`
-- Local management-metadata reads: `asm_list_resources`, `manage_webshell_list`, `c2_event`, `c2_file`
+- Local management-metadata reads: `manage_webshell_list`, `c2_event`, `c2_file`
 
 These built-in MCP reads remain constrained by RBAC and resource scope; the allowlist only bypasses HITL approval and does not grant additional access. `list_dir` is effective only when that is the actual tool name; the Eino filesystem directory-listing tool is named `ls`.
 
@@ -108,7 +108,7 @@ Avoid globally allowlisting:
 - File write/delete tools
 - C2 task tools
 - WebShell command execution tools
-- Nominally read-only tools that send requests to a target or external service, such as `webshell_file_read`, `webshell_file_list`, `search_knowledge_base`, and remote ASM task queries
+- Nominally read-only tools that send requests to a target or external service, such as `webshell_file_read`, `webshell_file_list`, and `search_knowledge_base`
 - Multiplexed tools whose actions include both reads and writes, such as `c2_session`, `c2_listener`, `c2_profile`, and `c2_task_manage`
 
 ## Mode Selection

--- a/docs/zh-CN/hitl-best-practices.md
+++ b/docs/zh-CN/hitl-best-practices.md
@@ -25,7 +25,7 @@ hitl:
     api_key: ""
     model: "" # 可填小模型；留空复用默认 AI 通道的模型
   retention_days: 90
-  tool_whitelist: [read_file, ls, glob, grep, tool_search, get_project_fact, list_project_facts, search_project_facts, list_vulnerabilities, get_vulnerability, get_asset, query_assets, list_knowledge_risk_types, get_tool_execution, wait_tool_execution, batch_task_list, batch_task_get, asm_list_resources, manage_webshell_list, c2_event, c2_file]
+  tool_whitelist: [read_file, ls, glob, grep, tool_search, get_project_fact, list_project_facts, search_project_facts, list_vulnerabilities, get_vulnerability, get_asset, query_assets, list_knowledge_risk_types, get_tool_execution, wait_tool_execution, batch_task_list, batch_task_get, manage_webshell_list, c2_event, c2_file]
 ```
 
 `audit_model` 的字段可以只填一部分。空字段会自动继承默认 AI 通道解析后的模型配置，因此常见做法是只填 `model`，让审计 Agent 使用更便宜的小模型。
@@ -98,7 +98,7 @@ hitl:
 - 项目与漏洞查询：`get_project_fact`、`list_project_facts`、`search_project_facts`、`list_vulnerabilities`、`get_vulnerability`
 - 资产与知识元数据查询：`get_asset`、`query_assets`、`list_knowledge_risk_types`
 - 执行与任务状态查询：`get_tool_execution`、`wait_tool_execution`、`batch_task_list`、`batch_task_get`
-- 本地管理元数据查询：`asm_list_resources`、`manage_webshell_list`、`c2_event`、`c2_file`
+- 本地管理元数据查询：`manage_webshell_list`、`c2_event`、`c2_file`
 
 上述内置 MCP 查询仍受 RBAC 和资源范围约束；白名单只跳过 HITL 审批，不扩大访问权限。`list_dir` 仅在实际工具名为该值时有效；Eino 文件系统的目录列表工具名是 `ls`。
 
@@ -108,7 +108,7 @@ hitl:
 - 文件写入/删除工具
 - C2 任务工具
 - WebShell 命令执行工具
-- 会向目标或外部服务发起请求的“只读”工具，例如 `webshell_file_read`、`webshell_file_list`、`search_knowledge_base` 和 ASM 远程任务查询
+- 会向目标或外部服务发起请求的“只读”工具，例如 `webshell_file_read`、`webshell_file_list` 和 `search_knowledge_base`
 - 同一工具名同时包含读写 action 的复合工具，例如 `c2_session`、`c2_listener`、`c2_profile`、`c2_task_manage`
 
 ## 模式选择


### PR DESCRIPTION
## 变更说明

官方 `main` 已删除 ASM MCP，并已从 `config.example.yaml` 的默认免审白名单中移除相关工具，但中英文 HITL 最佳实践文档仍保留相关描述。

本 PR：

- 从中文 HITL 白名单示例和推荐工具列表中移除 `asm_list_resources`
- 从英文 HITL 白名单示例和推荐工具列表中移除 `asm_list_resources`
- 删除“不建议加入白名单”章节中残留的“ASM 远程任务查询”中英文描述
- 保持文档与当前官方 MCP 能力及示例配置一致

## 验证

- 在版本化 README、`docs/`、`config.example.yaml` 和 `SECURITY.md` 中检索，确认 ASM / `asm_` 相关描述为 0
- `git diff --check` 通过
- 本次仅修改文档，不涉及运行时代码